### PR TITLE
Fix dataset path and optimizer reuse

### DIFF
--- a/datamodules/animegan_datamodule.py
+++ b/datamodules/animegan_datamodule.py
@@ -64,7 +64,7 @@ class AnimeDataSet(Dataset):
         return image, image_gray
 
     def load_anime_smooth(self, index: int) -> torch.Tensor:
-        fpath = self.anime_files[index]
+        fpath = self.smooth_files[index]
 
         image = Image.open(fpath).convert("L")  # Gray Scale
         image = self._transform(image)

--- a/pipelines/animegan_pipeline.py
+++ b/pipelines/animegan_pipeline.py
@@ -56,7 +56,7 @@ class AnimeganPipeline(pl.LightningModule):
         else:
             # After Pre-training
             photo, anime, gray, smooth = batch  # p, a, x, y
-            g_opt, d_opt = self.configure_optimizers()
+            g_opt, d_opt = self.optimizers()
 
             # | Discriminator |
             self.generator.requires_grad_(False)
@@ -231,7 +231,7 @@ class AnimeganPipeline(pl.LightningModule):
     def _pre_training(self, batch):
         self.generator.requires_grad_(True)
         self.discriminator.requires_grad_(False)
-        g_opt, _ = self.configure_optimizers()
+        g_opt, _ = self.optimizers()
 
         photo, _, _, _ = batch
         fake = self.generator(photo)


### PR DESCRIPTION
## Summary
- fix smooth image loading path in `AnimeDataSet`
- reuse optimizers during training by calling `self.optimizers()`

## Testing
- `python -m py_compile datamodules/animegan_datamodule.py pipelines/animegan_pipeline.py`
- `python test.py --checkpoint ./weights/paprika.pt --input_dir ./samples/inputs --output_dir ./samples/results --device cpu --upsample_align False --x32` *(fails: ModuleNotFoundError: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68528e9a8f748322af0dba0491180ed5